### PR TITLE
Simplify the usage of the check macro wrt. closures

### DIFF
--- a/omnomnomicon_derive/src/updater.rs
+++ b/omnomnomicon_derive/src/updater.rs
@@ -55,13 +55,16 @@ pub fn derive_updater_impl(omnom: OStruct) -> Result<TokenStream> {
         }
     };
 
-    let update_fields = fields.iter().map(|f| {
-        let OField { variant, ident, .. } = &f;
+    let update_fields = fields.iter().map(|&f| {
+        let OField {
+            variant, ident, ty, ..
+        } = f;
 
         let mut upd = quote! { self.#ident.apply(f) };
         for check in f.checks.iter() {
             upd = quote! {
-                #check(&self.#ident, &f)?;
+                let check_fn: fn(&#ty, &#ty) -> std::result::Result<(), String> = #check;
+                check_fn(&self.#ident, &f)?;
                 #upd
             };
         }

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -121,7 +121,7 @@ pub fn parse_command(input: &str) -> Result<Command> {
         mask_cmd,
         say_cmd,
         iv_cmd(&Config {
-            price: 10,
+            price: Price(10),
             boosting: Some(123),
             target: 10,
             limits: Limits {
@@ -360,7 +360,7 @@ impl Default for Limits {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            price: 50,
+            price: Price(50),
             target: 150,
             limits: Limits::default(),
             boosting: None,
@@ -372,6 +372,9 @@ impl Default for Config {
         }
     }
 }
+
+#[derive(Debug, Clone, omnomnomicon::Parser)]
+pub struct Price(u32);
 
 fn ten_percent(orig: &u32, new: &u32) -> std::result::Result<(), String> {
     let diff = (*orig as i32 - *new as i32) * 100 / (*orig as i32);
@@ -390,8 +393,8 @@ fn ten_percent(orig: &u32, new: &u32) -> std::result::Result<(), String> {
 #[derive(Debug, Clone, Updater)]
 pub struct Config {
     /// Price...
-    #[om(check(ten_percent))]
-    pub price: u32,
+    #[om(check((|cur: &Price, new: &Price| ten_percent(&cur.0, &new.0))))]
+    pub price: Price,
     #[om(check(ten_percent))]
     pub target: u32,
     #[om(enter)]

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -393,7 +393,7 @@ fn ten_percent(orig: &u32, new: &u32) -> std::result::Result<(), String> {
 #[derive(Debug, Clone, Updater)]
 pub struct Config {
     /// Price...
-    #[om(check((|cur: &Price, new: &Price| ten_percent(&cur.0, &new.0))))]
+    #[om(check(|cur, new| ten_percent(&cur.0, &new.0)))]
     pub price: Price,
     #[om(check(ten_percent))]
     pub target: u32,


### PR DESCRIPTION
This PR simplifies usage of the check macro. The check macro accepts a closure but it has to be parenthesized and also sometimes parameters needs to be type annotated. These issues are demonstrated in the first commit. With this PR they're fixed by binding the check function to a variable with an explicit type annotation.

The tutorial has been extended and updated accordingly.