### PR TITLE
Relax the type signature of the check function to accept a closure with free variables

### DIFF
--- a/omnomnomicon_derive/src/updater.rs
+++ b/omnomnomicon_derive/src/updater.rs
@@ -63,7 +63,7 @@ pub fn derive_updater_impl(omnom: OStruct) -> Result<TokenStream> {
         let mut upd = quote! { self.#ident.apply(f) };
         for check in f.checks.iter() {
             upd = quote! {
-                let check_fn: fn(&#ty, &#ty) -> std::result::Result<(), String> = #check;
+                let check_fn: &dyn Fn(&#ty, &#ty) -> std::result::Result<(), String> = &#check;
                 check_fn(&self.#ident, &f)?;
                 #upd
             };

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -401,7 +401,7 @@ pub struct Config {
     /// Price...
     #[om(check(|cur, new| ten_percent(&cur.0, &new.0)))]
     pub price: Price,
-    #[om(check(|cur, new| percent(15.0)(cur, new)))]
+    #[om(check(percent(15.0)))]
     pub target: u32,
     #[om(enter)]
     pub limits: Limits,


### PR DESCRIPTION
This PR relaxes the limitations of what can be passed to the check macro. Previously the check function has to be a function. Now it can be a closure with free variables so that manually carried functions can be used.

A demonstrating example is added to the tutorial.