### PR TITLE
Fix the wrong type in the second argument of dcheck

### DIFF
--- a/omnomnomicon_derive/src/patch.rs
+++ b/omnomnomicon_derive/src/patch.rs
@@ -304,7 +304,7 @@ impl ToTokens for Top {
                     }
                 } else {
                     quote! {
-                        let check_fn: &dyn Fn(&#ty, &#ty) -> std::result::Result<(), String> = &#dcheck;
+                        let check_fn: &dyn Fn(&#ty, &<#ty as ::omnomnomicon::Updater>::Updater) -> std::result::Result<(), String> = &#dcheck;
                         if let Err(err) = check_fn(&self.#accessor, &val) {
                             errors.push(err);
                         }

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -639,6 +639,27 @@ mod test {
             #[om(check(|_| Ok(())))] i64,
         );
     }
+
+    #[cfg(feature = "enum-map")]
+    #[test]
+    fn enum_map_dcheck() {
+        #[derive(Debug, Updater)]
+        struct Foo {
+            #[om(dcheck(check_bar))]
+            bar: EnumMap<bool, f64>,
+        }
+
+        fn check_bar(
+            current: &EnumMap<bool, f64>,
+            (key, new): &(bool, f64),
+        ) -> std::result::Result<(), String> {
+            let current = &current[*key];
+            if *current * 2.0 != *new {
+                return Err("This can only be doubled".into());
+            }
+            Ok(())
+        }
+    }
 }
 
 fn must_xor(s: &Config2) -> std::result::Result<(), String> {


### PR DESCRIPTION
This patch also adds an example in the tutorial.